### PR TITLE
Delete .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,0 @@
-*.fbx filter=lfs diff=lfs merge=lfs -text
-*.psd filter=lfs diff=lfs merge=lfs -text
-*.png filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Remove .gitattributes. Only contains LFS properties.